### PR TITLE
improve unit-testability of spec/store/index.spec.js

### DIFF
--- a/packages/nuxt-testing-environment/spec/store/index.spec.js
+++ b/packages/nuxt-testing-environment/spec/store/index.spec.js
@@ -4,16 +4,14 @@ import { createLocalVue } from '@vue/test-utils'
 import cloneDeep from 'lodash.clonedeep'
 
 describe('store/index.js', () => {
-  let store
-
   beforeEach(() => {
     const localVue = createLocalVue()
     localVue.use(Vuex)
-    store = new Vuex.Store(cloneDeep(index))
   })
 
   describe('mutations', () => {
     test('increment ミューテーションがコミットされると、 count ステートの値が +1 される)', () => {
+      const store = new Vuex.Store(cloneDeep(index))
       expect(store.getters['count']).toBe(0)
       store.commit('increment')
       expect(store.getters['count']).toBe(1)
@@ -22,9 +20,14 @@ describe('store/index.js', () => {
 
   describe('actions', () => {
     test('increment アクションを dispatch するたびに、 increment ミューテーションがコミットされる', () => {
-      expect(store.getters['count']).toBe(0)
+      // incrementミューテーションをモックしてVuexストアを構築する
+      const mutations = {
+        increment: jest.fn()
+      }
+      const store = new Vuex.Store({ ...cloneDeep(index), mutations })
+
       store.dispatch('increment')
-      expect(store.getters['count']).toBe(1)
+      expect(mutations.increment).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
下記課題の解決

- mutations.incrementに依存しており、actions.incrementの単体テストになっていない
- mutations.incrementがcommitされることが保証されない
    (他のmutationによりcountが1増加していても検出できない)

以上、よろしくお願いいたします。